### PR TITLE
v1.1.0 - Java 8 Compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>dte</groupId>
 	<artifactId>tzevaadomapi</artifactId>
-	<version>1.0.0</version>
+	<version>1.1.0</version>
 
 	<build>
 		<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -43,18 +43,28 @@
 			<version>1.1.1</version>
 		</dependency>
 		
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<version>5.2.0</version>
-			<scope>test</scope>
-		</dependency>
-		
+		<!-- Junit -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
 			<version>5.9.2</version>
 			<scope>test</scope>
+		</dependency>
+		
+		<!-- Mockito Core -->
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>4.11.0</version>
+			<scope>test</scope>
+		</dependency>
+		
+		<!-- Mockito Junit Jupiter Extension -->
+		<dependency>
+    		<groupId>org.mockito</groupId>
+    		<artifactId>mockito-junit-jupiter</artifactId>
+    		<version>4.11.0</version>
+    		<scope>test</scope>
 		</dependency>
 		
 	</dependencies>

--- a/src/main/java/dte/tzevaadomapi/alert/Alert.java
+++ b/src/main/java/dte/tzevaadomapi/alert/Alert.java
@@ -6,17 +6,24 @@ import java.util.Objects;
 public class Alert
 {
 	private final String city;
+	private final String title;
 	private final LocalDateTime date;
 	
-	public Alert(String city, LocalDateTime date) 
+	public Alert(String city, String title, LocalDateTime date) 
 	{
 		this.city = city;
+		this.title = title;
 		this.date = date;
 	}
 	
 	public String getCity() 
 	{
 		return this.city;
+	}
+	
+	public String getTitle() 
+	{
+		return this.title;
 	}
 	
 	public LocalDateTime getDate() 
@@ -27,7 +34,7 @@ public class Alert
 	@Override
 	public int hashCode()
 	{
-		return Objects.hash(this.city, this.date);
+		return Objects.hash(this.city, this.title, this.date);
 	}
 	
 	@Override
@@ -41,12 +48,14 @@ public class Alert
 		
 		Alert other = (Alert) object;
 		
-		return Objects.equals(this.city, other.city) && Objects.equals(this.date, other.date);
+		return Objects.equals(this.city, other.city) && 
+				Objects.equals(this.title, other.title) &&
+				Objects.equals(this.date, other.date);
 	}
 	
 	@Override
 	public String toString()
 	{
-		return String.format("Alert [city=%s, date=%s]", this.city, this.date);
+		return String.format("Alert [city=%s, title=%s, date=%s]", this.city, this.title, this.date);
 	}
 }

--- a/src/main/java/dte/tzevaadomapi/alertsource/PHOAlertSource.java
+++ b/src/main/java/dte/tzevaadomapi/alertsource/PHOAlertSource.java
@@ -25,8 +25,9 @@ public class PHOAlertSource extends JSONAlertSource
 	protected Alert fromJSON(JSONObject alertJson) 
 	{
 		String city = (String) alertJson.get("data");
+		String title = (String) alertJson.get("title");
 		LocalDateTime date = LocalDateTime.parse((String) alertJson.get("alertDate"), DATE_FORMATTER);
 		
-		return new Alert(city, date);
+		return new Alert(city, title, date);
 	}
 }

--- a/src/main/java/dte/tzevaadomapi/alertsource/PHOAlertSource.java
+++ b/src/main/java/dte/tzevaadomapi/alertsource/PHOAlertSource.java
@@ -22,10 +22,10 @@ public class PHOAlertSource extends JSONAlertSource
 	}
 	
 	@Override
-	protected Alert fromJSON(JSONObject alertJSON) 
+	protected Alert fromJSON(JSONObject alertJson) 
 	{
-		String city = (String) alertJSON.get("data");
-		LocalDateTime date = LocalDateTime.parse((String) alertJSON.get("alertDate"), DATE_FORMATTER);
+		String city = (String) alertJson.get("data");
+		LocalDateTime date = LocalDateTime.parse((String) alertJson.get("alertDate"), DATE_FORMATTER);
 		
 		return new Alert(city, date);
 	}

--- a/src/main/java/dte/tzevaadomapi/alertsource/json/JSONAlertSource.java
+++ b/src/main/java/dte/tzevaadomapi/alertsource/json/JSONAlertSource.java
@@ -28,29 +28,25 @@ public abstract class JSONAlertSource implements AlertSource
 	@Override
 	public Alert getMostRecentAlert() throws Exception
 	{
-		JSONArray alertsJSON = requestAlertsJSON();
+		JSONArray alertsJsonArray = requestAlertsJSON();
 		
-		if(alertsJSON == null || alertsJSON.isEmpty())
+		if(alertsJsonArray == null || alertsJsonArray.isEmpty())
 			throw new IllegalArgumentException("Cannot get the most recent alert due to an empty JSON response!");
 		
-		JSONObject mostRecentAlertJSON = (JSONObject) alertsJSON.get(0);
-		
-		return fromJSON(mostRecentAlertJSON);
+		return fromJSON((JSONObject) alertsJsonArray.get(0));
 	}
 	
-	protected abstract Alert fromJSON(JSONObject alertJSON);
+	protected abstract Alert fromJSON(JSONObject alertJson);
 	
 	private JSONArray requestAlertsJSON() throws Exception
 	{
-		String alertsJSONText;
-		
 		try(CloseableHttpClient httpClient = HttpClients.createDefault();
 				CloseableHttpResponse response = httpClient.execute(new HttpGet(this.requestURL))) 
 		{
 			HttpEntity entity = response.getEntity();
+			String alertsJsonText = (entity != null ? EntityUtils.toString(entity) : null);
 			
-			alertsJSONText = (entity != null ? EntityUtils.toString(entity) : null);
+			return (JSONArray) JSONValue.parse(alertsJsonText);
 		}
-		return (JSONArray) JSONValue.parse(alertsJSONText);
 	}
 }

--- a/src/main/java/dte/tzevaadomapi/alertsource/json/JSONAlertSource.java
+++ b/src/main/java/dte/tzevaadomapi/alertsource/json/JSONAlertSource.java
@@ -33,7 +33,7 @@ public abstract class JSONAlertSource implements AlertSource
 		if(alertsJSON == null || alertsJSON.isEmpty())
 			throw new IllegalArgumentException("Cannot get the most recent alert due to an empty JSON response!");
 		
-		JSONObject mostRecentAlertJSON = (JSONObject) alertsJSON.get(alertsJSON.size()-1);
+		JSONObject mostRecentAlertJSON = (JSONObject) alertsJSON.get(0);
 		
 		return fromJSON(mostRecentAlertJSON);
 	}

--- a/src/main/java/dte/tzevaadomapi/notifier/TzevaAdomNotifier.java
+++ b/src/main/java/dte/tzevaadomapi/notifier/TzevaAdomNotifier.java
@@ -81,11 +81,6 @@ public class TzevaAdomNotifier implements Iterable<Alert>
 		return this.initialRequestTime;
 	}
 
-	public int size()
-	{
-		return this.history.size();
-	}
-
 	@Override
 	public Iterator<Alert> iterator() 
 	{

--- a/src/main/java/dte/tzevaadomapi/notifier/TzevaAdomNotifier.java
+++ b/src/main/java/dte/tzevaadomapi/notifier/TzevaAdomNotifier.java
@@ -101,7 +101,7 @@ public class TzevaAdomNotifier implements Iterable<Alert>
 	{
 		private AlertSource alertSource;
 		private Duration requestDelay;
-		private Consumer<Exception> requestFailureHandler;
+		private Consumer<Exception> requestFailureHandler = (exception) -> {};
 		private Set<Consumer<Alert>> listeners = new HashSet<>();
 
 		public Builder requestFrom(AlertSource alertSource) 
@@ -132,7 +132,6 @@ public class TzevaAdomNotifier implements Iterable<Alert>
 		{
 			Objects.requireNonNull(this.alertSource, "The source of the alerts must be provided!");
 			Objects.requireNonNull(this.requestDelay, "The delay between requesting alerts must be provided!");
-			Objects.requireNonNull(this.requestFailureHandler, "The alerts' request failure handler must be provided!");
 			
 			TzevaAdomNotifier notifier = new TzevaAdomNotifier(this.alertSource, this.requestDelay, this.requestFailureHandler);
 			this.listeners.forEach(notifier::addListener);

--- a/src/main/java/dte/tzevaadomapi/notifier/TzevaAdomNotifier.java
+++ b/src/main/java/dte/tzevaadomapi/notifier/TzevaAdomNotifier.java
@@ -40,7 +40,7 @@ public class TzevaAdomNotifier implements Iterable<Alert>
 	public void listen() throws InterruptedException
 	{
 		//start with an initial alert - against which future alerts will be compared
-		Alert mostRecentAlert = getMostRecentAlert();
+		Alert lastTzevaAdom = getMostRecentAlert();
 
 		while(true)
 		{
@@ -49,10 +49,10 @@ public class TzevaAdomNotifier implements Iterable<Alert>
 			Alert alert = getMostRecentAlert();
 			
 			//if the last alert in history doesn't equal to the last requested one - It's TZEVA ADOM
-			if(mostRecentAlert.equals(alert)) 
+			if(lastTzevaAdom.equals(alert)) 
 				continue;
 			
-			mostRecentAlert = alert;
+			lastTzevaAdom = alert;
 			
 			this.listeners.forEach(listener -> listener.accept(alert));
 			this.history.add(alert);

--- a/src/main/java/dte/tzevaadomapi/notifier/TzevaAdomNotifier.java
+++ b/src/main/java/dte/tzevaadomapi/notifier/TzevaAdomNotifier.java
@@ -43,8 +43,7 @@ public class TzevaAdomNotifier implements Iterable<Alert>
 	public void listen() throws InterruptedException
 	{
 		//start with an initial alert - against which future alerts will be compared
-		this.history.add(getMostRecentAlert());
-		this.initialRequestTime = LocalDateTime.now();
+		Alert mostRecentAlert = getMostRecentAlert();
 
 		while(true)
 		{
@@ -53,8 +52,10 @@ public class TzevaAdomNotifier implements Iterable<Alert>
 			Alert alert = getMostRecentAlert();
 			
 			//if the last alert in history doesn't equal to the last requested one - It's TZEVA ADOM
-			if(this.history.peekLast().equals(alert))
+			if(mostRecentAlert.equals(alert)) 
 				continue;
+			
+			mostRecentAlert = alert;
 			
 			this.listeners.forEach(listener -> listener.accept(alert));
 			this.history.add(alert);
@@ -89,6 +90,9 @@ public class TzevaAdomNotifier implements Iterable<Alert>
 
 	private Alert getMostRecentAlert()
 	{
+		if(this.initialRequestTime == null)
+			this.initialRequestTime = LocalDateTime.now();
+		
 		while(true) 
 		{
 			try 

--- a/src/main/java/dte/tzevaadomapi/notifier/TzevaAdomNotifier.java
+++ b/src/main/java/dte/tzevaadomapi/notifier/TzevaAdomNotifier.java
@@ -1,7 +1,6 @@
 package dte.tzevaadomapi.notifier;
 
 import java.time.Duration;
-import java.time.LocalDateTime;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -30,8 +29,6 @@ public class TzevaAdomNotifier implements Iterable<Alert>
 	private final Consumer<Exception> requestFailureHandler;
 	private final Set<Consumer<Alert>> listeners = new HashSet<>();
 	private final Deque<Alert> history = new LinkedList<>();
-
-	private LocalDateTime initialRequestTime;
 
 	private TzevaAdomNotifier(AlertSource alertSource, Duration requestDelay, Consumer<Exception> requestFailureHandler) 
 	{
@@ -77,11 +74,6 @@ public class TzevaAdomNotifier implements Iterable<Alert>
 		return new LinkedHashSet<>(this.history);
 	}
 
-	public LocalDateTime getInitialRequestTime() 
-	{
-		return this.initialRequestTime;
-	}
-
 	@Override
 	public Iterator<Alert> iterator() 
 	{
@@ -90,9 +82,6 @@ public class TzevaAdomNotifier implements Iterable<Alert>
 
 	private Alert getMostRecentAlert()
 	{
-		if(this.initialRequestTime == null)
-			this.initialRequestTime = LocalDateTime.now();
-		
 		while(true) 
 		{
 			try 

--- a/src/main/java/dte/tzevaadomapi/notifier/TzevaAdomNotifier.java
+++ b/src/main/java/dte/tzevaadomapi/notifier/TzevaAdomNotifier.java
@@ -44,8 +44,6 @@ public class TzevaAdomNotifier implements Iterable<Alert>
 
 		while(true)
 		{
-			TimeUnit.MILLISECONDS.sleep(this.requestDelay.toMillis());
-
 			Alert alert = getMostRecentAlert();
 			
 			//if the last alert in history doesn't equal to the last requested one - It's TZEVA ADOM
@@ -80,11 +78,13 @@ public class TzevaAdomNotifier implements Iterable<Alert>
 		return this.history.iterator();
 	}
 
-	private Alert getMostRecentAlert()
+	private Alert getMostRecentAlert() throws InterruptedException
 	{
-		while(true) 
+		while(true)
 		{
-			try 
+			TimeUnit.MILLISECONDS.sleep(this.requestDelay.toMillis());
+				
+			try
 			{
 				return this.alertSource.getMostRecentAlert();
 			}

--- a/src/main/java/dte/tzevaadomapi/notifier/TzevaAdomNotifier.java
+++ b/src/main/java/dte/tzevaadomapi/notifier/TzevaAdomNotifier.java
@@ -128,6 +128,11 @@ public class TzevaAdomNotifier implements Iterable<Alert>
 			return this;
 		}
 		
+		public void listen() throws InterruptedException
+		{
+			build().listen();
+		}
+		
 		public TzevaAdomNotifier build()
 		{
 			Objects.requireNonNull(this.alertSource, "The source of the alerts must be provided!");

--- a/src/main/java/dte/tzevaadomapi/notifier/TzevaAdomNotifier.java
+++ b/src/main/java/dte/tzevaadomapi/notifier/TzevaAdomNotifier.java
@@ -13,6 +13,7 @@ import java.util.function.Consumer;
 
 import dte.tzevaadomapi.alert.Alert;
 import dte.tzevaadomapi.alertsource.AlertSource;
+import dte.tzevaadomapi.alertsource.PHOAlertSource;
 
 /**
  * Notifies registered listeners once a Tzeva Adom takes place.
@@ -35,6 +36,12 @@ public class TzevaAdomNotifier implements Iterable<Alert>
 		this.alertSource = alertSource;
 		this.requestDelay = requestDelay;
 		this.requestFailureHandler = requestFailureHandler;
+	}
+	
+	public static Builder requestFromPikudHaoref() 
+	{
+		return new Builder()
+				.requestFrom(new PHOAlertSource());
 	}
 
 	public void listen() throws InterruptedException

--- a/src/test/java/dte/tzevaadomapi/notifier/TzevaAdomNotifierTest.java
+++ b/src/test/java/dte/tzevaadomapi/notifier/TzevaAdomNotifierTest.java
@@ -1,12 +1,11 @@
 package dte.tzevaadomapi.notifier;
 
 import static dte.tzevaadomapi.utils.UncheckedExceptions.unchecked;
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 
 import org.junit.jupiter.api.Test;
@@ -34,7 +33,7 @@ public class TzevaAdomNotifierTest
 		Alert alert = new Alert("Tel Aviv", LocalDateTime.now());
 		when(this.alertSource.getMostRecentAlert()).thenReturn(alert, alert, alert);
 		
-		assertHistoryEquals(simulateNotifier(), alert);
+		assertEquals(0, simulateNotifier().getHistory().size());
 	}
 	
 	@Test
@@ -44,13 +43,7 @@ public class TzevaAdomNotifierTest
 		Alert secondAlert = new Alert("Haifa", LocalDateTime.now());
 		when(this.alertSource.getMostRecentAlert()).thenReturn(firstAlert, firstAlert, firstAlert, firstAlert, secondAlert);
 		
-		assertHistoryEquals(simulateNotifier(), firstAlert, secondAlert);
-	}
-	
-	
-	private static void assertHistoryEquals(TzevaAdomNotifier notifier, Alert... expectedHistory) 
-	{
-		assertIterableEquals(notifier.getHistory(), Arrays.asList(expectedHistory));
+		assertEquals(1, simulateNotifier().getHistory().size());
 	}
 	
 	/**

--- a/src/test/java/dte/tzevaadomapi/notifier/TzevaAdomNotifierTest.java
+++ b/src/test/java/dte/tzevaadomapi/notifier/TzevaAdomNotifierTest.java
@@ -2,7 +2,6 @@ package dte.tzevaadomapi.notifier;
 
 import static dte.tzevaadomapi.utils.UncheckedExceptions.unchecked;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
@@ -10,45 +9,42 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import dte.tzevaadomapi.alert.Alert;
 import dte.tzevaadomapi.alertsource.AlertSource;
 
 @TestInstance(Lifecycle.PER_CLASS)
+@ExtendWith(MockitoExtension.class)
 public class TzevaAdomNotifierTest
 {
-	private LocalDateTime now;
+	@Mock
 	private AlertSource alertSource;
 	
 	private static final Duration SIMULATION_DURATION = Duration.ofMillis(200);
-	
-	@BeforeAll
-	public void setup() throws Exception 
-	{
-		this.now = LocalDateTime.now();
-		this.alertSource = mock(AlertSource.class);
-	}
 
 	@Test
 	public void testNotTzevaAdom() throws Exception 
 	{
-		Alert alert = new Alert("Tel Aviv", this.now);
+		Alert alert = new Alert("Tel Aviv", LocalDateTime.now());
 		when(this.alertSource.getMostRecentAlert()).thenReturn(alert, alert, alert);
-		assertHistoryEquals(simulateNotifier(this.alertSource), alert);
+		
+		assertHistoryEquals(simulateNotifier(), alert);
 	}
 	
 	@Test
 	public void testTzevaAdomDetection() throws Exception
 	{
-		Alert firstAlert = new Alert("Tel Aviv", this.now);
-		Alert secondAlert = new Alert("Haifa", this.now);
-		
+		Alert firstAlert = new Alert("Tel Aviv", LocalDateTime.now());
+		Alert secondAlert = new Alert("Haifa", LocalDateTime.now());
 		when(this.alertSource.getMostRecentAlert()).thenReturn(firstAlert, firstAlert, firstAlert, firstAlert, secondAlert);
-		assertHistoryEquals(simulateNotifier(this.alertSource), firstAlert, secondAlert);
+		
+		assertHistoryEquals(simulateNotifier(), firstAlert, secondAlert);
 	}
 	
 	
@@ -57,11 +53,17 @@ public class TzevaAdomNotifierTest
 		assertIterableEquals(notifier.getHistory(), Arrays.asList(expectedHistory));
 	}
 	
-	private TzevaAdomNotifier simulateNotifier(AlertSource alertSource) throws InterruptedException 
+	/**
+	 * Runs a notifier(based on the mocked {@code alertSource}) for the defined <b>Simulation Duration</b>, and then returns it.
+	 * 
+	 * @return A notifier after a simulated run.
+	 * @throws InterruptedException when the sleeping between requests fails.
+	 */
+	private TzevaAdomNotifier simulateNotifier() throws InterruptedException 
 	{
 		TzevaAdomNotifier notifier = new TzevaAdomNotifier.Builder()
 				.every(Duration.ofMillis(5))
-				.requestFrom(alertSource)
+				.requestFrom(this.alertSource)
 				.onFailedRequest(Exception::printStackTrace)
 				.build();
 		

--- a/src/test/java/dte/tzevaadomapi/notifier/TzevaAdomNotifierTest.java
+++ b/src/test/java/dte/tzevaadomapi/notifier/TzevaAdomNotifierTest.java
@@ -31,19 +31,30 @@ public class TzevaAdomNotifierTest
 	public void testNotTzevaAdom() throws Exception 
 	{
 		Alert alert = createAlert("Tel Aviv");
-		when(this.alertSource.getMostRecentAlert()).thenReturn(alert, alert, alert);
 		
+		when(this.alertSource.getMostRecentAlert()).thenReturn(alert, alert, alert);
 		assertEquals(0, simulateNotifier().getHistory().size());
 	}
 	
 	@Test
-	public void testTzevaAdomDetection() throws Exception
+	public void testTzevaAdom() throws Exception
 	{
 		Alert firstAlert = createAlert("Tel Aviv");
 		Alert secondAlert = createAlert("Haifa");
-		when(this.alertSource.getMostRecentAlert()).thenReturn(firstAlert, firstAlert, firstAlert, firstAlert, secondAlert);
 		
+		when(this.alertSource.getMostRecentAlert()).thenReturn(firstAlert, firstAlert, firstAlert, firstAlert, secondAlert);
 		assertEquals(1, simulateNotifier().getHistory().size());
+	}
+	
+	@Test
+	public void testConsecutiveTzevaAdom() throws Exception 
+	{
+		Alert firstAlert = createAlert("Tel Aviv");
+		Alert secondAlert = createAlert("Haifa");
+		Alert thirdAlert = createAlert("Jerusalem");
+		
+		when(this.alertSource.getMostRecentAlert()).thenReturn(firstAlert, secondAlert, thirdAlert, firstAlert);
+		assertEquals(3, simulateNotifier().getHistory().size());
 	}
 	
 	private static Alert createAlert(String city) 

--- a/src/test/java/dte/tzevaadomapi/notifier/TzevaAdomNotifierTest.java
+++ b/src/test/java/dte/tzevaadomapi/notifier/TzevaAdomNotifierTest.java
@@ -24,8 +24,6 @@ public class TzevaAdomNotifierTest
 {
 	@Mock
 	private AlertSource alertSource;
-	
-	private static final Duration SIMULATION_DURATION = Duration.ofMillis(200);
 
 	@Test
 	public void testNotTzevaAdom() throws Exception 
@@ -33,7 +31,7 @@ public class TzevaAdomNotifierTest
 		Alert alert = createAlert("Tel Aviv");
 		
 		when(this.alertSource.getMostRecentAlert()).thenReturn(alert, alert, alert);
-		assertEquals(0, simulateNotifier().getHistory().size());
+		assertEquals(0, simulateNotifier(3).getHistory().size());
 	}
 	
 	@Test
@@ -43,7 +41,7 @@ public class TzevaAdomNotifierTest
 		Alert secondAlert = createAlert("Haifa");
 		
 		when(this.alertSource.getMostRecentAlert()).thenReturn(firstAlert, firstAlert, firstAlert, firstAlert, secondAlert);
-		assertEquals(1, simulateNotifier().getHistory().size());
+		assertEquals(1, simulateNotifier(5).getHistory().size());
 	}
 	
 	@Test
@@ -54,7 +52,7 @@ public class TzevaAdomNotifierTest
 		Alert thirdAlert = createAlert("Jerusalem");
 		
 		when(this.alertSource.getMostRecentAlert()).thenReturn(firstAlert, secondAlert, thirdAlert, firstAlert);
-		assertEquals(3, simulateNotifier().getHistory().size());
+		assertEquals(3, simulateNotifier(4).getHistory().size());
 	}
 	
 	private static Alert createAlert(String city) 
@@ -63,12 +61,12 @@ public class TzevaAdomNotifierTest
 	}
 	
 	/**
-	 * Runs a notifier(based on the mocked {@code alertSource}) for the defined <b>Simulation Duration</b>, and then returns it.
+	 * Runs a notifier that records the specified amount of dummy alerts, and then returns it.
 	 * 
 	 * @return A notifier after a simulated run.
 	 * @throws InterruptedException when the sleeping between requests fails.
 	 */
-	private TzevaAdomNotifier simulateNotifier() throws InterruptedException 
+	private TzevaAdomNotifier simulateNotifier(int alertsAmount) throws InterruptedException 
 	{
 		TzevaAdomNotifier notifier = new TzevaAdomNotifier.Builder()
 				.every(Duration.ofMillis(5))
@@ -77,7 +75,9 @@ public class TzevaAdomNotifierTest
 				.build();
 		
 		CompletableFuture.runAsync(unchecked(notifier::listen));
-		Thread.sleep(SIMULATION_DURATION.toMillis());
+		
+		//because I'm ahla gever, every alert gets 10ms to be recorded
+		Thread.sleep(Duration.ofMillis(alertsAmount * 10).toMillis());
 		
 		return notifier;
 	}

--- a/src/test/java/dte/tzevaadomapi/notifier/TzevaAdomNotifierTest.java
+++ b/src/test/java/dte/tzevaadomapi/notifier/TzevaAdomNotifierTest.java
@@ -30,7 +30,7 @@ public class TzevaAdomNotifierTest
 	@Test
 	public void testNotTzevaAdom() throws Exception 
 	{
-		Alert alert = new Alert("Tel Aviv", LocalDateTime.now());
+		Alert alert = createAlert("Tel Aviv");
 		when(this.alertSource.getMostRecentAlert()).thenReturn(alert, alert, alert);
 		
 		assertEquals(0, simulateNotifier().getHistory().size());
@@ -39,11 +39,16 @@ public class TzevaAdomNotifierTest
 	@Test
 	public void testTzevaAdomDetection() throws Exception
 	{
-		Alert firstAlert = new Alert("Tel Aviv", LocalDateTime.now());
-		Alert secondAlert = new Alert("Haifa", LocalDateTime.now());
+		Alert firstAlert = createAlert("Tel Aviv");
+		Alert secondAlert = createAlert("Haifa");
 		when(this.alertSource.getMostRecentAlert()).thenReturn(firstAlert, firstAlert, firstAlert, firstAlert, secondAlert);
 		
 		assertEquals(1, simulateNotifier().getHistory().size());
+	}
+	
+	private static Alert createAlert(String city) 
+	{
+		return new Alert(city, "חדירת מחבלים", LocalDateTime.now());
 	}
 	
 	/**


### PR DESCRIPTION
This update fixes various critical bugs, and adds convenient features :)

Changelog:

- [Added support for the `title` field from Pikud Ha'oref's json file.](https://github.com/DavidTheExplorer/Tzeva-Adom-API/commit/cd73286d2c5875c7fe5e5c2d79503915336c3a3f)
- [Added `TzevaAdomNotifier.Builder#listen` because the notifier object is mostly useless.](https://github.com/DavidTheExplorer/Tzeva-Adom-API/commit/d6cefde22a4f8cf239bdb464f4b284512b2b7d25)
- [Added a facade method to request alers from Pikud Ha'oref.](https://github.com/DavidTheExplorer/Tzeva-Adom-API/commit/f16bb27ae26dcb7588b017622f2e99b0d37fdab2)
- INCOMPATIBLE: Removed `#getInitialRequestTime` and `#size` from `TzevaAdomNotifier` because they were useless. (https://github.com/DavidTheExplorer/Tzeva-Adom-API/commit/ab4ce0eaa0a9bcfa454ce8c4dc3da657556dfc08) (https://github.com/DavidTheExplorer/Tzeva-Adom-API/commit/1535e7bb1ee4c7ca24e5ef1bf9b37d77e64377a0)
- [Fixed the API being uncompatible with Java 8(was 11+ before).](https://github.com/DavidTheExplorer/Tzeva-Adom-API/commit/0d0098e98ecb33b6384dbeb69869bc79026eb4c5)
- [Fixed Pikud HaOref's `AlertSource` returning the most outdated alert in the json file.](https://github.com/DavidTheExplorer/Tzeva-Adom-API/commit/9e3ed9a7ad868774c53e6c7fa0605306ef57ebd9)
- [Fixed accessing the notifier's history returning the initial alert.](https://github.com/DavidTheExplorer/Tzeva-Adom-API/commit/5c00d361e8816c251e47c5b3f5ce1470105e5b78)
- [Fixed no request delay after a failed request.](https://github.com/DavidTheExplorer/Tzeva-Adom-API/commit/2d599ec47618df0db0b9b413416256a654049c05)

