### PR TITLE
v1.3.0 - TzevaAdomListener interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>dte</groupId>
 	<artifactId>tzevaadomapi</artifactId>
-	<version>1.2.0</version>
+	<version>1.3.0</version>
 
 	<build>
 		<plugins>

--- a/src/main/java/dte/tzevaadomapi/notifier/TzevaAdomListener.java
+++ b/src/main/java/dte/tzevaadomapi/notifier/TzevaAdomListener.java
@@ -1,0 +1,9 @@
+package dte.tzevaadomapi.notifier;
+
+import dte.tzevaadomapi.alert.Alert;
+
+@FunctionalInterface
+public interface TzevaAdomListener
+{
+	void onTzevaAdom(Alert alert);
+}

--- a/src/main/java/dte/tzevaadomapi/notifier/TzevaAdomNotifier.java
+++ b/src/main/java/dte/tzevaadomapi/notifier/TzevaAdomNotifier.java
@@ -29,7 +29,7 @@ public class TzevaAdomNotifier implements Iterable<Alert>
 	private final AlertSource alertSource;
 	private final Duration requestDelay;
 	private final Consumer<Exception> requestFailureHandler;
-	private final Set<Consumer<Alert>> listeners = new HashSet<>();
+	private final Set<TzevaAdomListener> listeners = new HashSet<>();
 	private final Deque<Alert> history = new LinkedList<>();
 
 	private TzevaAdomNotifier(AlertSource alertSource, Duration requestDelay, Consumer<Exception> requestFailureHandler) 
@@ -66,15 +66,15 @@ public class TzevaAdomNotifier implements Iterable<Alert>
 				
 				lastTzevaAdom = alert;
 				
-				this.listeners.forEach(listener -> listener.accept(alert));
+				this.listeners.forEach(listener -> listener.onTzevaAdom(alert));
 				this.history.add(alert);
 			}
 		});
 	}
 
-	public void addListener(Consumer<Alert> tzevaAdomListener) 
+	public void addListener(TzevaAdomListener listener) 
 	{
-		this.listeners.add(tzevaAdomListener);
+		this.listeners.add(listener);
 	}
 
 	public Alert getLastAlert()
@@ -117,7 +117,7 @@ public class TzevaAdomNotifier implements Iterable<Alert>
 		private AlertSource alertSource;
 		private Duration requestDelay;
 		private Consumer<Exception> requestFailureHandler = (exception) -> {};
-		private Set<Consumer<Alert>> listeners = new HashSet<>();
+		private Set<TzevaAdomListener> listeners = new HashSet<>();
 
 		public Builder requestFrom(AlertSource alertSource) 
 		{
@@ -137,7 +137,7 @@ public class TzevaAdomNotifier implements Iterable<Alert>
 			return this;
 		}
 		
-		public Builder onTzevaAdom(Consumer<Alert> listener)
+		public Builder onTzevaAdom(TzevaAdomListener listener)
 		{
 			this.listeners.add(listener);
 			return this;

--- a/src/main/java/dte/tzevaadomapi/notifier/TzevaAdomNotifier.java
+++ b/src/main/java/dte/tzevaadomapi/notifier/TzevaAdomNotifier.java
@@ -21,10 +21,8 @@ import dte.tzevaadomapi.alertsource.PHOAlertSource;
  * <p>
  * A request for the most recent alert is sent every constant duration, and the result is then compared to the previous one.
  * If the 2 alerts don't equal - It's <b>Tzeva Adom</b> and the registered listeners are notified.
- * <p>
- * This class implements <b>Iterable{@literal <Alert>}</b> which returns the history of Tzeva Adom alerts.
  */
-public class TzevaAdomNotifier implements Iterable<Alert>
+public class TzevaAdomNotifier
 {
 	private final AlertSource alertSource;
 	private final Duration requestDelay;


### PR DESCRIPTION
This is technically a breaking update, but for a feature that was never used - iterating over a **TzevaAdomNotifier** object.

Changelog:
- [Added `TzevaAdomListener` to replace `Consumer<Alert>`](https://github.com/DavidTheExplorer/Tzeva-Adom-API/commit/28985473e94d9fca21b64fc8692aadff1544fc30) - This simplifies both client code & the experience of the developers reading the library.
- [`TzevaAdomNotifier` is no longer `Iterable`](https://github.com/DavidTheExplorer/Tzeva-Adom-API/commit/b9b777ddcf6047ee267abd31951af7529f5e2405) - It should have never been so, because conceptually a notifier is not a collection of anything.

